### PR TITLE
go-tupleconv: change the datetime conversion logic, improve tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed 
+
+- time formats, supported by `StringToDatetimeConverter`. Now there are two supported formats:
+   - with numeric tz offset: `2006-01-02T15:04:05.999999999-0700`
+   - with tz name: `2006-01-02T15:04:05.999999999 Europe/Moscow`

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,31 @@
+BSD 2-Clause License
+
+Copyright (c) 2023, Tarantool AUTHORS
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or
+without modification, are permitted provided that the following
+conditions are met:
+
+1. Redistributions of source code must retain the above
+   copyright notice, this list of conditions and the
+   following disclaimer.
+
+2. Redistributions in binary form must reproduce the above
+   copyright notice, this list of conditions and the following
+   disclaimer in the documentation and/or other materials
+   provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY AUTHORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+AUTHORS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.

--- a/example_test.go
+++ b/example_test.go
@@ -214,8 +214,8 @@ func ExampleMap_insertMappedTuples() {
 	decoder := tupleconv.MakeMapper(converters).
 		WithDefaultConverter(fac.GetStringConverter())
 
-	dt1 := "2020-08-22T11:27:43.123456789-02:00"
-	dt2 := "1880-01-01T00:00:00Z"
+	dt1 := "2020-08-22T11:27:43.123456789-0200"
+	dt2 := "1880-01-01T00:00:00-0000"
 	uuid := "00000000-0000-0000-0000-000000000001"
 	interval := "1,2,3,4,5,6,7,8,1"
 
@@ -272,7 +272,7 @@ func ExampleMap_insertMappedTuples() {
 	//  true
 	//  12
 	//  143.5
-	//  2020-08-22 13:27:43.123456789 +0000 UTC
+	//  2020-08-22 11:27:43.123456789 -0200 -0200
 	//  <nil>
 	//  str
 	//  <nil>

--- a/tt_test.go
+++ b/tt_test.go
@@ -19,20 +19,24 @@ func TestStringToTTConvFactory(t *testing.T) {
 	nullUUID, err := uuid.Parse("00000000-0000-0000-0000-000000000000")
 	require.NoError(t, err)
 
-	time1, err := time.Parse(time.RFC3339, "2020-08-22T11:27:43.123456789-02:00")
+	parisLoc, err := time.LoadLocation("Europe/Paris")
 	require.NoError(t, err)
-	datetime1, err := datetime.NewDatetime(time1.UTC())
-	require.NoError(t, err)
+	time1 := time.Date(2020, 8, 22, 11, 27, 43,
+		123456789, time.FixedZone("", -2*60*60))
+	time2 := time.Date(2022, 7, 26, 17, 6, 49, 809892000,
+		time.FixedZone("", +3*60*60))
+	time3 := time.Date(2022, 7, 26, 17, 06, 49,
+		809892000, parisLoc)
+	time4 := time.Date(2023, 8, 30, 12, 6, 5, 120000000,
+		time.FixedZone("", 0))
+	time5 := time.Date(2023, 8, 30, 12, 6, 5, 120000000,
+		parisLoc)
 
-	time2, err := time.Parse(time.RFC3339, "1880-01-01T00:00:00Z")
-	require.NoError(t, err)
-	datetime2, err := datetime.NewDatetime(time2.UTC())
-	require.NoError(t, err)
-
-	time3, err := time.Parse("2006-01-02 15:04:05", "2023-08-30 11:11:00")
-	require.NoError(t, err)
-	datetime3, err := datetime.NewDatetime(time3.UTC())
-	require.NoError(t, err)
+	datetime1 := getDatetimeWithValidate(t, time1)
+	datetime2 := getDatetimeWithValidate(t, time2)
+	datetime3 := getDatetimeWithValidate(t, time3)
+	datetime4 := getDatetimeWithValidate(t, time4)
+	datetime5 := getDatetimeWithValidate(t, time5)
 
 	fac := tupleconv.MakeStringToTTConvFactory().
 		WithNullValue("null").
@@ -161,10 +165,11 @@ func TestStringToTTConvFactory(t *testing.T) {
 		},
 		tupleconv.TypeDatetime: {
 			// Basic.
-			{value: "2020-08-22T11:27:43.123456789-02:00", expected: datetime1},
-			{value: "1880-01-01T00:00:00Z", expected: datetime2},
-			{value: "1880-01-01", expected: datetime2},
-			{value: "2023-08-30 11:11:00", expected: datetime3},
+			{value: "2020-08-22T11:27:43.123456789-0200", expected: datetime1},
+			{value: "2022-07-26T17:06:49.809892+0300", expected: datetime2},
+			{value: "2022-07-26T17:06:49.809892 Europe/Paris", expected: datetime3},
+			{value: "2023-08-30T12:06:05.120-0000", expected: datetime4},
+			{value: "2023-08-30T12:06:05.120 Europe/Paris", expected: datetime5},
 
 			// Nullable.
 			{value: "null", isNullable: true, expected: nil},
@@ -280,7 +285,7 @@ func TestStringToTTConvFactory(t *testing.T) {
 			{value: "false", expected: false},
 			{value: "", isNullable: true, expected: ""},
 			{value: "09b56913-11f0-4fa4-b5d0-901b5efa532a", expected: someUUID},
-			{value: "2020-08-22T11:27:43.123456789-02:00", expected: datetime1},
+			{value: "2020-08-22T11:27:43.123456789-0200", expected: datetime1},
 			{
 				value: "1,2,3,4,5,6,7,8,1",
 				expected: datetime.Interval{
@@ -305,7 +310,7 @@ func TestStringToTTConvFactory(t *testing.T) {
 			{value: "false", expected: false},
 			{value: "", isNullable: true, expected: ""},
 			{value: "09b56913-11f0-4fa4-b5d0-901b5efa532a", expected: someUUID},
-			{value: "2020-08-22T11:27:43.123456789-02:00", expected: datetime1},
+			{value: "2020-08-22T11:27:43.123456789-0200", expected: datetime1},
 			{
 				value: "1,2,3,4,5,6,7,8,1",
 				expected: datetime.Interval{


### PR DESCRIPTION
`Datetime` conversion logic changes:
- Supported time layouts have been modified to be more strict.
- Added parsing of time zone names for time formats without a numerical offset.

Other:
- Added test to check conversion error with conversion list from `MakeStringToTTConvFactory`.
- Added license.