### PR TITLE
converters: add datetime/interval to string converters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Changed 
+### Changed
 
 - time formats, supported by `StringToDatetimeConverter`. Now there are two supported formats:
    - with numeric tz offset: `2006-01-02T15:04:05.999999999-0700`
    - with tz name: `2006-01-02T15:04:05.999999999 Europe/Moscow`
+
+### Added
+
+- `DatetimeToStringConverter`: converter from `datetime.Datetime` to string with a format
+  similar to that supported by `StringToDatetimeConverter`.
+- `IntervalToStringConverter`: converter from `datetime.Interval` to string with a format
+  similar to that supported by `StringToIntervalConverter`.

--- a/converter.go
+++ b/converter.go
@@ -32,6 +32,9 @@ var (
 	_ Converter[string, any] = (*StringToNullConverter)(nil)
 	_ Converter[string, any] = (*IdentityConverter[string])(nil)
 	_ Converter[string, any] = (*StringToIntervalConverter)(nil)
+
+	_ Converter[*datetime.Datetime, string] = (*DatetimeToStringConverter)(nil)
+	_ Converter[datetime.Interval, string]  = (*IntervalToStringConverter)(nil)
 )
 
 // IdentityConverter is a converter from S to any, that doesn't change the input.
@@ -328,4 +331,40 @@ func (StringToIntervalConverter) Convert(src string) (any, error) {
 		Adjust: adjust,
 	}
 	return interval, nil
+}
+
+// DatetimeToStringConverter is a converter from datetime.Datetime to string.
+type DatetimeToStringConverter struct{}
+
+// MakeDatetimeToStringConverter creates DatetimeToStringConverter.
+func MakeDatetimeToStringConverter() DatetimeToStringConverter {
+	return DatetimeToStringConverter{}
+}
+
+// Convert is the implementation of Converter[*datetime.Datetime, string]
+// for DatetimeToStringConverter.
+func (DatetimeToStringConverter) Convert(datetime *datetime.Datetime) (string, error) {
+	tm := datetime.ToTime()
+	zone := tm.Location().String()
+	if zone != "" {
+		return fmt.Sprintf("%s %s", tm.Format(dateTimeLayout), zone), nil
+	}
+	return tm.Format(dateTimeOffsetLayout), nil
+}
+
+// IntervalToStringConverter is a converter from datetime.Interval to string.
+type IntervalToStringConverter struct{}
+
+// MakeIntervalToStringConverter creates IntervalToStringConverter.
+func MakeIntervalToStringConverter() IntervalToStringConverter {
+	return IntervalToStringConverter{}
+}
+
+// Convert is the implementation of Converter[datetime.Interval, string]
+// for IntervalToStringConverter.
+func (IntervalToStringConverter) Convert(interval datetime.Interval) (string, error) {
+	ret := fmt.Sprintf("%d,%d,%d,%d,%d,%d,%d,%d,%d",
+		interval.Year, interval.Month, interval.Week, interval.Day, interval.Hour, interval.Min,
+		interval.Sec, interval.Nsec, interval.Adjust)
+	return ret, nil
 }

--- a/testdata/config.lua
+++ b/testdata/config.lua
@@ -26,6 +26,21 @@ box.once('init', function()
     })
 
     box.space.test_space:create_index('primary')
+
+    box.schema.create_space('finances', {
+        format = {
+            { name = 'id', type = 'unsigned' },
+            { name = 'money', type = 'number' },
+            { name = 'date', type = 'datetime' }
+        }
+    })
+
+    box.space.finances:create_index('primary')
+
+    datetime = require('datetime')
+    box.space.finances:insert { 1, 14.15, datetime.new({ year = 2023, month = 8, day = 30, hour = 12, min = 13 }) }
+    box.space.finances:insert { 2, 19.3e4, datetime.new({ year = 2023, month = 8, day = 31, tz = 'Europe/Paris' }) }
+    box.space.finances:insert { 3, -111111, datetime.new({ year = 2023, month = 9, day = 2, min = 1, tzoffset = 240 }) }
 end)
 
 function get_test_space_fmt()


### PR DESCRIPTION
- `DatetimeToStringConverter`, `IntervalToStringConverter` have been added.
-  The examples have been improved.