### PR TITLE
fix: parsing any to slice and array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- `StringToMapConverter` and `StringToSliceConverter` parse "null" strings to strings.
+
+### Fixed
+
+- `GetAnyConverter`: don't parse any to slices and arrays. 
+
 ## [v1.0.0] - 2024-10-09
 
 The release updates `go-tarantool` connector from `v1` to `v2`.

--- a/converter.go
+++ b/converter.go
@@ -219,6 +219,8 @@ func (StringToDatetimeConverter) Convert(src string) (any, error) {
 	return datetime.MakeDatetime(tm)
 }
 
+var errFailToConvertStringToMap = errors.New("can't convert string to map")
+
 // StringToMapConverter is a converter from string to map.
 // Only `json` is supported now.
 type StringToMapConverter struct{}
@@ -235,8 +237,13 @@ func (StringToMapConverter) Convert(src string) (any, error) {
 	if err != nil {
 		return nil, err
 	}
+	if _, ok := result.(map[string]any); !ok {
+		return nil, errFailToConvertStringToMap
+	}
 	return result, nil
 }
+
+var errFailToConvertStringToSlice = errors.New("can't convert string to slice")
 
 // StringToSliceConverter is a converter from string to slice.
 // Only `json` is supported now.
@@ -253,6 +260,9 @@ func (StringToSliceConverter) Convert(src string) (any, error) {
 	err := json.Unmarshal([]byte(src), &result)
 	if err != nil {
 		return nil, err
+	}
+	if _, ok := result.([]any); !ok {
+		return nil, errFailToConvertStringToSlice
 	}
 	return result, nil
 }

--- a/converter_test.go
+++ b/converter_test.go
@@ -25,6 +25,7 @@ func HelperTestConverter[S any, T any](
 	t *testing.T,
 	mp tupleconv.Converter[S, T],
 	cases []convCase[S, T]) {
+	t.Helper()
 	for _, tc := range cases {
 		t.Run(fmt.Sprintln(tc.value), func(t *testing.T) {
 			result, err := mp.Convert(tc.value)
@@ -379,7 +380,6 @@ func TestMakeSequenceConverter(t *testing.T) {
 		{value: "-10", expected: int64(-10)},
 		{value: "2.5", expected: 2.5},
 		{value: "{}", expected: map[string]any{}},
-		{value: "null", expected: nil}, // As `json`.
 
 		// Error.
 		{value: "12-13-14", isErr: true},

--- a/example_test.go
+++ b/example_test.go
@@ -203,7 +203,7 @@ func upTarantool() (func(), error) {
 	})
 	if err != nil {
 		test_helpers.StopTarantoolWithCleanup(inst)
-		return nil, nil
+		return nil, err
 	}
 
 	cleanup := func() {
@@ -235,7 +235,11 @@ func ExampleMap_insertMappedTuples() {
 	}
 	defer cleanupTarantool()
 
-	conn, _ := tarantool.Connect(context.Background(), dialer, opts)
+	conn, err := tarantool.Connect(context.Background(), dialer, opts)
+	if err != nil {
+		fmt.Printf("can't connect to tarantool: %v\n", err)
+		return
+	}
 	defer conn.Close()
 
 	var spaceFmtResp [][]tupleconv.SpaceField
@@ -313,7 +317,11 @@ func Example_ttEncoder() {
 	tupleEncoder := tupleconv.MakeMapper([]tupleconv.Converter[any, string]{}).
 		WithDefaultConverter(converter)
 
-	conn, _ := tarantool.Connect(context.Background(), dialer, opts)
+	conn, err := tarantool.Connect(context.Background(), dialer, opts)
+	if err != nil {
+		fmt.Printf("can't connect to tarantool: %v\n", err)
+		return
+	}
 	defer conn.Close()
 
 	req := tarantool.NewSelectRequest("finances")

--- a/tt.go
+++ b/tt.go
@@ -179,6 +179,8 @@ func (fac StringToTTConvFactory) GetAnyConverter() Converter[string, any] {
 		fac.GetDatetimeConverter(),
 		fac.GetUUIDConverter(),
 		fac.GetIntervalConverter(),
+		fac.GetArrayConverter(),
+		fac.GetMapConverter(),
 		fac.GetStringConverter(),
 	})
 }

--- a/tt_test.go
+++ b/tt_test.go
@@ -208,7 +208,7 @@ func TestStringToTTConvFactory(t *testing.T) {
 					},
 				},
 			},
-			{value: "null", expected: nil},
+			{value: "null", isErr: true},
 
 			// Nullable.
 			{value: "null", isNullable: true, expected: nil},
@@ -300,6 +300,22 @@ func TestStringToTTConvFactory(t *testing.T) {
 					Year: -11, Month: -1110, Nsec: 1, Adjust: 2,
 				},
 			},
+			{
+				value:    "[1, 2, 3, 4]",
+				expected: []any{float64(1), float64(2), float64(3), float64(4)},
+			},
+			{
+				value: `{"1": [1,2,3], "2": {"a":4} }`,
+				expected: map[string]any{
+					"1": []any{float64(1), float64(2), float64(3)},
+					"2": map[string]any{
+						"a": float64(4),
+					},
+				},
+			},
+			{value: "null", expected: "null"},
+			{value: "nil", expected: "nil"},
+			{value: "NULL", expected: "NULL"},
 		},
 		tupleconv.TypeScalar: {
 			{value: "1`e2", expected: 100.0},


### PR DESCRIPTION
It was fixed that Any was not parsed in slice or array. In addition, the behavior of parsing null strings has been changed. It is now expected to be a string.

Closes TNTP-4101